### PR TITLE
🐛 Fix emojis in Renovate config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 - ✨ Synchronize support resources ([#23]) ([**@denialhaag**])
 - ✨ Synchronize issue templates ([#21]) ([**@denialhaag**])
 
+### Fixed
+
+- 🐛 Fix emojis in Renovate config ([#32]) ([**@denialhaag**])
+
 ## [1.0.0]
 
 ### Added
@@ -33,6 +37,7 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 <!-- PR links -->
 
+[#32]: https://github.com/munich-quantum-toolkit/templates/pull/32
 [#25]: https://github.com/munich-quantum-toolkit/templates/pull/25
 [#24]: https://github.com/munich-quantum-toolkit/templates/pull/24
 [#23]: https://github.com/munich-quantum-toolkit/templates/pull/23

--- a/templates/renovate.json5
+++ b/templates/renovate.json5
@@ -17,7 +17,7 @@
     {
       matchManagers: ["cargo"],
       addLabels: ["rust"],
-      commitMessagePrefix: "⬆\uD83E\uDD80"
+      commitMessagePrefix: "⬆\uFE0F\uD83E\uDD80"
     },
     {
       matchManagers: ["github-actions"],
@@ -27,7 +27,7 @@
     {
       matchManagers: ["npm"],
       addLabels: ["javascript"],
-      commitMessagePrefix: "⬆\uD83D\uDCDC"
+      commitMessagePrefix: "⬆\uFE0F\uD83D\uDCDC"
     },
     {
       matchManagers: ["pep621"],


### PR DESCRIPTION
## Description

This PR fixes the emojis in the Renovate config that are used for the PR titles.

The error was spotted in https://github.com/cda-tum/mqt-naviz/pull/106#discussion_r2241760677.

## Checklist:

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
