### PR TITLE
🐛 Fix whitespace in installation guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ## [Unreleased]
 
+## [1.1.2] - 2025-09-01
+
+- 🐛 Fix whitespace in installation guide ([#51]) ([**@denialhaag**])
+
 ## [1.1.1] - 2025-09-01
 
 ### Fixed
@@ -49,14 +53,16 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#110)._
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/munich-quantum-toolkit/templates/compare/v1.1.1...HEAD
+[unreleased]: https://github.com/munich-quantum-toolkit/templates/compare/v1.1.2...HEAD
+[1.1.2]: https://github.com/munich-quantum-toolkit/templates/releases/tag/v1.1.2
 [1.1.1]: https://github.com/munich-quantum-toolkit/templates/releases/tag/v1.1.1
 [1.1.0]: https://github.com/munich-quantum-toolkit/templates/releases/tag/v1.1.0
 [1.0.0]: https://github.com/munich-quantum-toolkit/templates/releases/tag/v1.0.0
 
 <!-- PR links -->
 
-[#50]: https://github.com/munich-quantum-toolkit/templates/pull/??
+[#51]: https://github.com/munich-quantum-toolkit/templates/pull/51
+[#50]: https://github.com/munich-quantum-toolkit/templates/pull/50
 [#45]: https://github.com/munich-quantum-toolkit/templates/pull/45
 [#32]: https://github.com/munich-quantum-toolkit/templates/pull/32
 [#31]: https://github.com/munich-quantum-toolkit/templates/pull/31

--- a/templates/installation.md
+++ b/templates/installation.md
@@ -1,14 +1,20 @@
 <!--- This file has been generated from an external template. Please do not modify it directly. -->
 <!--- Changes should be contributed to https://github.com/munich-quantum-toolkit/templates. -->
 
+{%- if project_type == "c++-python" %}
+
 # Installation
 
-{% if project_type == "c++-python" %}
 MQT {{name}} is primarily developed as a C++20 library with Python bindings.
 The Python package is available on [PyPI](https://pypi.org/project/mqt.{{repository}}/) and can be installed on all major operating systems with all supported Python versions.
+
 {%- elif project_type == "pure-python" %}
+
+# Installation
+
 MQT {{name}} is a Python package available on [PyPI](https://pypi.org/project/mqt.{{repository}}/).
 It can be installed on all major operating systems with all supported Python versions.
+
 {%- endif %}
 
 :::::{tip}


### PR DESCRIPTION
## Description

This PR fixes a whitespace in the installation guide that was not fixed by #50.

The problem came up in https://github.com/munich-quantum-toolkit/core/pull/1171 and https://github.com/munich-quantum-toolkit/qecc/pull/491.

This PR also prepares the release of `v1.1.2` so that this fix can be rolled out immediately. 

## Checklist:

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~I have added appropriate tests that cover the new/changed functionality.~
- [x] ~I have updated the documentation to reflect these changes.~
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] ~I have added migration instructions to the upgrade guide (if needed).~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
