### PR TITLE
🎨 Add `other` as possible `project_type`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ## [Unreleased]
 
+### Added
+
+- 🎨 Add `other` as possible `project_type` ([#54]) ([**@denialhaag**])
+
 ## [1.1.2] - 2025-09-01
 
 - 🐛 Fix whitespace in installation guide ([#51]) ([**@denialhaag**])
@@ -61,6 +65,7 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#110)._
 
 <!-- PR links -->
 
+[#54]: https://github.com/munich-quantum-toolkit/templates/pull/54
 [#51]: https://github.com/munich-quantum-toolkit/templates/pull/51
 [#50]: https://github.com/munich-quantum-toolkit/templates/pull/50
 [#45]: https://github.com/munich-quantum-toolkit/templates/pull/45

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,6 +4,9 @@ This document describes breaking changes and how to upgrade. For a complete list
 
 ## [Unreleased]
 
+While not a breaking change, `other` has been added as a `project_type`.
+For this `project_type`, the contribution and installation guides cannot be synchronized.
+
 ## [1.1.0]
 
 With this release, the templating Action has new required inputs:

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,7 @@ inputs:
     options:
       - c++-python
       - pure-python
+      - other
   repository:
     description: Name of the repository
     required: true

--- a/ruff.toml
+++ b/ruff.toml
@@ -19,7 +19,6 @@ ignore = [
     "C90",     # <...> too complex
     "COM812",  # Conflicts with formatter
     "CPY001",  # Missing copyright notice at top of file
-    "DOC501",  # Missing exceptions in docstring
     "ISC001",  # Conflicts with formatter
     "PLR09",   # Too many <...>
     "PLR2004", # Magic value used in comparison

--- a/ruff.toml
+++ b/ruff.toml
@@ -19,6 +19,7 @@ ignore = [
     "C90",     # <...> too complex
     "COM812",  # Conflicts with formatter
     "CPY001",  # Missing copyright notice at top of file
+    "DOC501",  # Missing exceptions in docstring
     "ISC001",  # Conflicts with formatter
     "PLR09",   # Too many <...>
     "PLR2004", # Magic value used in comparison

--- a/src/run.py
+++ b/src/run.py
@@ -62,6 +62,14 @@ def main(
     release_drafter_categories: str,
 ) -> None:
     """Render all templates."""
+    if project_type == "other":
+        if synchronize_contribution_guide:
+            msg = "Contribution guide cannot be synchronized for project type 'other'."
+            raise ValueError(msg)
+        if synchronize_installation_guide:
+            msg = "Installation guide cannot be synchronized for project type 'other'."
+            raise ValueError(msg)
+
     if not release_drafter_categories:
         release_drafter_categories = Path(DEFAULTS_DIR / "release_drafter_categories.json").read_text(encoding="utf-8")
     release_drafter_categories_dict = json.loads(release_drafter_categories)
@@ -229,7 +237,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--project_type",
         type=str,
-        choices=["c++-python", "pure-python"],
+        choices=["c++-python", "pure-python", "other"],
         required=True,
         help="Type of the project",
     )

--- a/src/run.py
+++ b/src/run.py
@@ -61,7 +61,11 @@ def main(
     synchronize_support_resources: bool,
     release_drafter_categories: str,
 ) -> None:
-    """Render all templates."""
+    """Render all templates.
+
+    Raises:
+        ValueError: If the arguments are incompatible with each other.
+    """
     if project_type == "other":
         if synchronize_contribution_guide:
             msg = "Contribution guide cannot be synchronized for project type 'other'."


### PR DESCRIPTION
## Description

This PR adds `other` as a possible `project_type`. This is useful for repositories such as `ddvis`, `naviz`, `templates`, and `workflows`. If `other` is used, the contribution and installation guides cannot be synchronized.

## Checklist:

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~I have added appropriate tests that cover the new/changed functionality.~
- [x] ~I have updated the documentation to reflect these changes.~
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
