### PR TITLE
🐛 Allow `name` to contain whitespace character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ## [Unreleased]
 
+## [1.1.4] - 2025-09-02
+
+### Fixed
+
+- 🐛 Allow `name` to contain whitespace character ([#58]) ([**@denialhaag**])
+
 ## [1.1.3] - 2025-09-02
 
 _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#113)._
@@ -62,7 +68,8 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#110)._
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/munich-quantum-toolkit/templates/compare/v1.1.3...HEAD
+[unreleased]: https://github.com/munich-quantum-toolkit/templates/compare/v1.1.4...HEAD
+[1.1.4]: https://github.com/munich-quantum-toolkit/templates/releases/tag/v1.1.4
 [1.1.3]: https://github.com/munich-quantum-toolkit/templates/releases/tag/v1.1.3
 [1.1.2]: https://github.com/munich-quantum-toolkit/templates/releases/tag/v1.1.2
 [1.1.1]: https://github.com/munich-quantum-toolkit/templates/releases/tag/v1.1.1
@@ -71,6 +78,7 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#110)._
 
 <!-- PR links -->
 
+[#58]: https://github.com/munich-quantum-toolkit/templates/pull/58
 [#55]: https://github.com/munich-quantum-toolkit/templates/pull/55
 [#54]: https://github.com/munich-quantum-toolkit/templates/pull/54
 [#51]: https://github.com/munich-quantum-toolkit/templates/pull/51

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 - 🐛 Allow `name` to contain whitespace character ([#58]) ([**@denialhaag**])
 
+### Changed
+
+- 🎨 Improve wording in issue templates ([#57]) ([**@denialhaag**])
+- 🎨 Improve Renovate configuration ([#57]) ([**@denialhaag**])
+
 ## [1.1.3] - 2025-09-02
 
 _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#113)._
@@ -24,7 +29,13 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#113)._
 - 🎨 Add `has_changelog_and_upgrade_guide` flag to make templates more generic ([#55]) ([**@denialhaag**])
 - 🎨 Add `other` as possible `project_type` ([#54]) ([**@denialhaag**])
 
+### Changed
+
+- 🎨 Add `hpca` key to `lit_header.bib` ([#53]) ([**@denialhaag**])
+
 ## [1.1.2] - 2025-09-01
+
+### Fixed
 
 - 🐛 Fix whitespace in installation guide ([#51]) ([**@denialhaag**])
 
@@ -79,8 +90,10 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#110)._
 <!-- PR links -->
 
 [#58]: https://github.com/munich-quantum-toolkit/templates/pull/58
+[#57]: https://github.com/munich-quantum-toolkit/templates/pull/57
 [#55]: https://github.com/munich-quantum-toolkit/templates/pull/55
 [#54]: https://github.com/munich-quantum-toolkit/templates/pull/54
+[#53]: https://github.com/munich-quantum-toolkit/templates/pull/53
 [#51]: https://github.com/munich-quantum-toolkit/templates/pull/51
 [#50]: https://github.com/munich-quantum-toolkit/templates/pull/50
 [#45]: https://github.com/munich-quantum-toolkit/templates/pull/45

--- a/action.yml
+++ b/action.yml
@@ -86,7 +86,7 @@ runs:
         RELEASE_DRAFTER_CATEGORIES: ${{ inputs.release-drafter-categories }}
       run: |
         uv run $GITHUB_ACTION_PATH/src/run.py \
-          --name $NAME \
+          --name "$NAME" \
           --organization $ORGANIZATION \
           --project_type $PROJECT_TYPE \
           --repository $REPOSITORY \


### PR DESCRIPTION
## Description

This PR makes it so that the `name` can contain whitespace characters. This is currently relevant for the `workflows` repository: https://github.com/munich-quantum-toolkit/workflows/pull/194

Furthermore, this PR prepares the release of v1.1.4.

## Checklist:

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~I have added appropriate tests that cover the new/changed functionality.~
- [x] ~I have updated the documentation to reflect these changes.~
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] ~I have added migration instructions to the upgrade guide (if needed).~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.