### PR TITLE
👷 Specify versioning of `henryiii/validate-pyproject-schema-store`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -46,7 +46,7 @@
     {
       matchManagers: ["pre-commit"],
       matchPackageNames: ["henryiii/validate-pyproject-schema-store"],
-      "versioning": "pep440"
+      versioning: "pep440"
     },
     {
       description: "Automerge patch updates",


### PR DESCRIPTION
## Description

This PR specifies the versioning of `henryiii/validate-pyproject-schema-store` in the Renovate config in an effort to test if this will lead to the dependency being recognized by Renovate.

## Checklist:

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~I have added appropriate tests that cover the new/changed functionality.~
- [x] ~I have updated the documentation to reflect these changes.~
- [x] ~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~
- [x] ~I have added migration instructions to the upgrade guide (if needed).~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a Renovate rule to manage a specific pre-commit dependency (henryiii/validate-pyproject-schema-store) using PEP 440 versioning; it’s added alongside existing rules and does not change other configurations.
  * Improves accuracy and consistency of automated updates for that pre-commit package, reducing manual version handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->