### PR TITLE
👷 Use `pep440` versioning for all `pre-commit` dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -45,7 +45,6 @@
     },
     {
       matchManagers: ["pre-commit"],
-      matchPackageNames: ["henryiii/validate-pyproject-schema-store"],
       versioning: "pep440"
     },
     {


### PR DESCRIPTION
## Description

This PR sets the versioning of all `pre-commit` dependencies to `pep440` in the Renovate configuration.

## Checklist:

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~I have added appropriate tests that cover the new/changed functionality.~
- [x] ~I have updated the documentation to reflect these changes.~
- [x] ~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~
- [x] ~I have added migration instructions to the upgrade guide (if needed).~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
