### PR TITLE
📝 Update default macOS runners in contribution guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ## [Unreleased]
 
+### Changed
+
+- 📝 Update default macOS runners in contribution guide ([#282]) ([**@denialhaag**])
+
 ## [1.2.0] - 2026-03-12
 
 _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#120)._
@@ -192,6 +196,7 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#110)._
 
 <!-- PR links -->
 
+[#282]: https://github.com/munich-quantum-toolkit/templates/pull/282
 [#247]: https://github.com/munich-quantum-toolkit/templates/pull/247
 [#241]: https://github.com/munich-quantum-toolkit/templates/pull/241
 [#238]: https://github.com/munich-quantum-toolkit/templates/pull/238

--- a/templates/docs_contributing.md
+++ b/templates/docs_contributing.md
@@ -168,8 +168,8 @@ As of August 2025, our CI pipeline on GitHub continuously tests the library acro
 
 - {code}`ubuntu-24.04`: {code}`Release` and {code}`Debug` builds using {code}`gcc`
 - {code}`ubuntu-24.04-arm`: {code}`Release` build using {code}`gcc`
-- {code}`macos-15`: {code}`Release` and {code}`Debug` builds using {code}`AppleClang`
-- {code}`macos-15-intel`: {code}`Release` build using {code}`AppleClang`
+- {code}`macos-26`: {code}`Release` and {code}`Debug` builds using {code}`AppleClang`
+- {code}`macos-26-intel`: {code}`Release` build using {code}`AppleClang`
 - {code}`windows-2025`: {code}`Release` and {code}`Debug` builds using {code}`msvc`
 - {code}`windows-11-arm`: {code}`Release` build using {code}`msvc`
 


### PR DESCRIPTION
## Description

This PR updates the default macOS runners in the contribution guide to `macos-26` and `macos-26-intel`

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
