### PR TITLE
🔧 Run `rumdl` hook with `--fix` flag

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -103,6 +103,7 @@ repos:
     rev: v0.2.17
     hooks:
       - id: rumdl
+        args: [--fix]
         priority: 5
       - id: rumdl-fmt
         priority: 6


### PR DESCRIPTION
## Description

This PR ensures that the `rumdl` hook runs with the `--fix` flag, after the [default behavior was changed in `v0.2.15`](https://github.com/rvben/rumdl-pre-commit/releases/tag/v0.2.15).

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] ~~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~~
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
