### PR TITLE
🐛 Run `prek` from root of target repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ with the exception that minor releases may include breaking changes.
 
 ## [Unreleased]
 
+## [1.3.1] - 2026-06-17
+
+### Fixed
+
+- 🐛 Run `prek` from root of target repository ([#344]) ([**@denialhaag**])
+
 ## [1.3.0] - 2026-06-16
 
 _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#130)._
@@ -224,7 +230,8 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#110)._
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/munich-quantum-toolkit/templates/compare/v1.3.0...HEAD
+[unreleased]: https://github.com/munich-quantum-toolkit/templates/compare/v1.3.1...HEAD
+[1.3.1]: https://github.com/munich-quantum-toolkit/templates/releases/tag/v1.3.1
 [1.3.0]: https://github.com/munich-quantum-toolkit/templates/releases/tag/v1.3.0
 [1.2.0]: https://github.com/munich-quantum-toolkit/templates/releases/tag/v1.2.0
 [1.1.13]: https://github.com/munich-quantum-toolkit/templates/releases/tag/v1.1.13
@@ -245,6 +252,7 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#110)._
 
 <!-- PR links -->
 
+[#344]: https://github.com/munich-quantum-toolkit/templates/pull/344
 [#338]: https://github.com/munich-quantum-toolkit/templates/pull/338
 [#332]: https://github.com/munich-quantum-toolkit/templates/pull/332
 [#328]: https://github.com/munich-quantum-toolkit/templates/pull/328

--- a/src/mqt/templates/render_templates.py
+++ b/src/mqt/templates/render_templates.py
@@ -82,6 +82,8 @@ def render_templates(
     Raises:
         ValueError: If the arguments are incompatible with each other or if the project type is not supported.
     """
+    target_dir = target_dir.resolve()
+
     supported_project_types = ["pure-python", "c++-python", "c++-mlir-python", "other"]
     if project_type not in supported_project_types:
         msg = f"Project type '{project_type}' is not supported. Must be one of {supported_project_types}."

--- a/src/mqt/templates/render_templates.py
+++ b/src/mqt/templates/render_templates.py
@@ -236,7 +236,7 @@ def render_templates(
         if template_container.arguments is None:
             _copy_template(template_container, output_dir)
         else:
-            _render_template(environment, template_container, output_dir)
+            _render_template(environment, template_container, target_dir)
 
 
 def _copy_template(template_container: TemplateContainer, output_dir: Path) -> None:
@@ -252,7 +252,7 @@ def _copy_template(template_container: TemplateContainer, output_dir: Path) -> N
         output_path.write_text(output, encoding="utf-8")
 
 
-def _render_template(environment: jinja2.Environment, template_container: TemplateContainer, output_dir: Path) -> None:
+def _render_template(environment: jinja2.Environment, template_container: TemplateContainer, target_dir: Path) -> None:
     """Render a template."""
     if template_container.active:
         assert template_container.arguments is not None
@@ -263,8 +263,8 @@ def _render_template(environment: jinja2.Environment, template_container: Templa
         output = template.render(**template_container.arguments)
 
         # Write the rendered template to a file
-        output_path = output_dir / template_container.file_name
+        output_path = target_dir / template_container.output_dir / template_container.file_name
         output_path.write_text(output + "\n", encoding="utf-8")
 
         # Format the rendered template
-        subprocess.run(["prek", "run", "--files", str(output_path)], check=False)
+        subprocess.run(["prek", "run", "--files", str(output_path)], cwd=target_dir, check=False)


### PR DESCRIPTION
## Description

This PR fixes a bug encountered in https://github.com/munich-quantum-toolkit/core/pull/1790. Because `prek` is not running from the current directory, it cannot find the pre-commit and `rumdl` configurations in the target repository. This PR fixes this by setting the `cwd` argument of `subprocess.run`.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
