### PR TITLE
🔖 Prepare release of `v1.4.3`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#143)._
 ### Changed
 
 - 📝 Require LLVM/MLIR for `c++-mlir-python` projects and remove the obsolete
-  instructions for disabling MLIR ([**@burgholzer**])
+  instructions for disabling MLIR ([#384]) ([**@burgholzer**])
 
 ## [1.4.2] - 2026-07-29
 
@@ -322,6 +322,7 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#110)._
 
 <!-- PR links -->
 
+[#384]: https://github.com/munich-quantum-toolkit/templates/pull/384
 [#383]: https://github.com/munich-quantum-toolkit/templates/pull/383
 [#377]: https://github.com/munich-quantum-toolkit/templates/pull/377
 [#369]: https://github.com/munich-quantum-toolkit/templates/pull/369

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ releases may include breaking changes.
 
 ## [Unreleased]
 
+## [1.4.3] - 2026-07-29
+
+_If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#143)._
+
+### Changed
+
+- 📝 Require LLVM/MLIR for `c++-mlir-python` projects and remove the obsolete
+  instructions for disabling MLIR ([**@burgholzer**])
+
 ## [1.4.2] - 2026-07-29
 
 _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#142)._
@@ -285,7 +294,8 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#110)._
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/munich-quantum-toolkit/templates/compare/v1.4.2...HEAD
+[unreleased]: https://github.com/munich-quantum-toolkit/templates/compare/v1.4.3...HEAD
+[1.4.3]: https://github.com/munich-quantum-toolkit/templates/releases/tag/v1.4.3
 [1.4.2]: https://github.com/munich-quantum-toolkit/templates/releases/tag/v1.4.2
 [1.4.1]: https://github.com/munich-quantum-toolkit/templates/releases/tag/v1.4.1
 [1.4.0]: https://github.com/munich-quantum-toolkit/templates/releases/tag/v1.4.0

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,12 @@ of changes, including minor and patch releases, please refer to the
 
 ## [Unreleased]
 
+## [1.4.3]
+
+The installation guide for `c++-mlir-python` projects now treats LLVM/MLIR as a
+mandatory source-build dependency. It no longer documents a generated
+`BUILD_MQT_<NAME>_MLIR` CMake option for disabling MLIR.
+
 ## [1.4.2]
 
 AI assistance must still be disclosed in the pull request description, and
@@ -139,7 +145,8 @@ jobs:
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/munich-quantum-toolkit/templates/compare/v1.4.2...HEAD
+[unreleased]: https://github.com/munich-quantum-toolkit/templates/compare/v1.4.3...HEAD
+[1.4.3]: https://github.com/munich-quantum-toolkit/templates/compare/v1.4.2...v1.4.3
 [1.4.2]: https://github.com/munich-quantum-toolkit/templates/compare/v1.4.1...v1.4.2
 [1.4.0]: https://github.com/munich-quantum-toolkit/templates/compare/v1.3.3...v1.4.0
 [1.3.3]: https://github.com/munich-quantum-toolkit/templates/compare/v1.3.0...v1.3.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "uv_build"
 
 [project]
 name = "mqt-templates"
-version = "1.4.2"
+version = "1.4.3"
 authors = [
   { name="Daniel Haag", email = "daniel.haag@tum.de" },
   { name="Lukas Burgholzer", email = "burgholzer@me.com" },

--- a/templates/installation.md
+++ b/templates/installation.md
@@ -406,8 +406,8 @@ guidelines and workflows, see {doc}`contributing`.
 
 {%- if project_type == "c++-mlir-python" %}
 
-6. If you plan to contribute to MQT {{name}}, you will also need to install
-   MLIR. The section below describes how to do this.
+6. Install LLVM/MLIR as described below. It is required to build MQT {{name}}
+   from source.
 
 (setting-up-mlir)=
 
@@ -517,16 +517,6 @@ $env:MLIR_DIR = "C:\path\to\installation\lib\cmake\mlir"
 :::
 
 ::::
-
-### Disabling MLIR
-
-If you do not need MLIR-based functionality, you can disable it by setting the
-{code}`BUILD_MQT_{{name.upper()}}_MLIR` option to {code}`OFF`. This disables all
-MLIR-related features in MQT {{name}} and removes the dependency on MLIR.
-
-```console
-cmake -S . -B build -DBUILD_MQT_{{name.upper()}}_MLIR=OFF
-```
 
 [`setup-mlir`]: https://github.com/munich-quantum-software/setup-mlir/
 [`portable-mlir-toolchain`]: https://github.com/munich-quantum-software/portable-mlir-toolchain/

--- a/tests/test_render_templates.py
+++ b/tests/test_render_templates.py
@@ -128,6 +128,14 @@ def test_non_other(temp_dir: Path, project_type: str, *, has_changelog_and_upgra
     _check_files(files)
     _check_ai_guidance(temp_dir, has_agents_md=True)
 
+    installation = " ".join((temp_dir / "docs" / "installation.md").read_text().split())
+    if project_type == "c++-mlir-python":
+        assert "Install LLVM/MLIR as described below. It is required to build MQT Test from source." in installation
+        assert "Disabling MLIR" not in installation
+        assert "BUILD_MQT_TEST_MLIR" not in installation
+    else:
+        assert "Setting Up MLIR" not in installation
+
 
 def test_other(temp_dir: Path) -> None:
     """Test that templates for `other` projects are rendered correctly."""

--- a/uv.lock
+++ b/uv.lock
@@ -86,7 +86,7 @@ wheels = [
 
 [[package]]
 name = "mqt-templates"
-version = "1.4.2"
+version = "1.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Prepare the v1.4.3 release and align the `c++-mlir-python` installation template with projects that require LLVM/MLIR for every source build.

The template now states that LLVM/MLIR is mandatory and no longer generates instructions for a `BUILD_MQT_<NAME>_MLIR` switch. This prevents munich-quantum-toolkit/core#1963 from restoring the option removed by munich-quantum-toolkit/core#1953. It also removes an invalid generated option from `core-plugins-catalyst`, the only other consumer of this template variant.

## Validation

- `uv run --group test python -m pytest` (9 passed)
- `uv run prek run --all-files`
- Rendered the updated installation template into the exact head of Core PR #1963 and ran Core's changed-file checks; the resulting `docs/installation.md` matches current Core `main` exactly.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/templates/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.