### PR TITLE
🔖 Prepare release of `v1.4.2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,21 +10,14 @@ releases may include breaking changes.
 
 ## [Unreleased]
 
-## [1.4.3] - 2026-07-29
-
-_If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#143)._
-
-### Changed
-
-- 📝 Require LLVM/MLIR for `c++-mlir-python` projects and remove the obsolete
-  instructions for disabling MLIR ([#384]) ([**@burgholzer**])
-
 ## [1.4.2] - 2026-07-29
 
 _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#142)._
 
 ### Changed
 
+- 📝 Require LLVM/MLIR for `c++-mlir-python` projects and remove the obsolete
+  instructions for disabling MLIR ([#384]) ([**@burgholzer**])
 - 🤖 Require disclosure of AI assistance in the PR description and recommend
   commit-level `Assisted-by` attribution ([#383]) ([**@burgholzer**])
 - 🧪 Keep tests in their respective test trees, organized by owning component,
@@ -294,8 +287,7 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#110)._
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/munich-quantum-toolkit/templates/compare/v1.4.3...HEAD
-[1.4.3]: https://github.com/munich-quantum-toolkit/templates/releases/tag/v1.4.3
+[unreleased]: https://github.com/munich-quantum-toolkit/templates/compare/v1.4.2...HEAD
 [1.4.2]: https://github.com/munich-quantum-toolkit/templates/releases/tag/v1.4.2
 [1.4.1]: https://github.com/munich-quantum-toolkit/templates/releases/tag/v1.4.1
 [1.4.0]: https://github.com/munich-quantum-toolkit/templates/releases/tag/v1.4.0

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,13 +6,11 @@ of changes, including minor and patch releases, please refer to the
 
 ## [Unreleased]
 
-## [1.4.3]
+## [1.4.2]
 
 The installation guide for `c++-mlir-python` projects now treats LLVM/MLIR as a
 mandatory source-build dependency. It no longer documents a generated
 `BUILD_MQT_<NAME>_MLIR` CMake option for disabling MLIR.
-
-## [1.4.2]
 
 AI assistance must still be disclosed in the pull request description, and
 agent-authored public text still requires the visible disclosure described in
@@ -145,8 +143,7 @@ jobs:
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/munich-quantum-toolkit/templates/compare/v1.4.3...HEAD
-[1.4.3]: https://github.com/munich-quantum-toolkit/templates/compare/v1.4.2...v1.4.3
+[unreleased]: https://github.com/munich-quantum-toolkit/templates/compare/v1.4.2...HEAD
 [1.4.2]: https://github.com/munich-quantum-toolkit/templates/compare/v1.4.1...v1.4.2
 [1.4.0]: https://github.com/munich-quantum-toolkit/templates/compare/v1.3.3...v1.4.0
 [1.3.3]: https://github.com/munich-quantum-toolkit/templates/compare/v1.3.0...v1.3.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "uv_build"
 
 [project]
 name = "mqt-templates"
-version = "1.4.3"
+version = "1.4.2"
 authors = [
   { name="Daniel Haag", email = "daniel.haag@tum.de" },
   { name="Lukas Burgholzer", email = "burgholzer@me.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -86,7 +86,7 @@ wheels = [
 
 [[package]]
 name = "mqt-templates"
-version = "1.4.3"
+version = "1.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Consolidate the merged v1.4.2 and v1.4.3 release preparations into the single unpublished v1.4.2 release.

PR #383 prepared v1.4.2 but the corresponding tag and release were never published. PR #384 then prepared v1.4.3 under the mistaken assumption that v1.4.2 had already been released. This corrective PR:

- folds the MLIR template change from #384 into the v1.4.2 changelog and upgrade-guide sections;
- removes the premature v1.4.3 sections and links; and
- restores `pyproject.toml` and `uv.lock` to version 1.4.2.

The existing v1.4.2 draft release remains unpublished and targets `main`, so it can be published after this PR is merged.

## Validation

- `uv lock`
- `uv run --group test python -m pytest` (9 passed)
- `uv run prek run --all-files`
- Independent exact-candidate verification (9 passed; no v1.4.3 references; no scope expansion)

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/templates/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.