### PR TITLE
🔧 Migrate Release Drafter configuration

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -5,51 +5,64 @@ name-template: "MQT Templates $RESOLVED_VERSION Release"
 tag-template: "v$RESOLVED_VERSION"
 categories:
   - title: "🚀 Features and Enhancements"
-    labels:
-      - "enhancement"
-      - "feature"
-      - "refactor"
-      - "usability"
+    when:
+      labels:
+        - "enhancement"
+        - "feature"
+        - "refactor"
+        - "usability"
   - title: "🐛 Bug Fixes"
-    labels:
-      - "bug"
-      - "fix"
+    when:
+      labels:
+        - "bug"
+        - "fix"
   - title: "📄 Documentation"
-    labels:
-      - "documentation"
-  - title: "🤖 CI"
-    labels:
-      - "continuous integration"
+    when:
+      labels:
+        - "documentation"
+  - title: "🤖 CI & Tooling"
+    when:
+      labels:
+        - "continuous integration"
+        - "tooling"
   - title: "📦 Packaging"
-    labels:
-      - "packaging"
+    when:
+      labels:
+        - "packaging"
   - title: "🧹 Code Quality"
-    labels:
-      - "code quality"
+    when:
+      labels:
+        - "code quality"
   - title: "⬆️ Dependencies"
     collapse-after: 5
-    labels:
-      - "dependencies"
-      - "github-actions"
-      - "pre-commit"
-      - "submodules"
+    when:
+      labels:
+        - "dependencies"
+        - "github-actions"
+        - "pre-commit"
+        - "submodules"
+  - type: "pre-exclude"
+    when:
+      labels:
+        - "skip-changelog"
+        - "backport"
+        - "release-prep"
+  - type: "version-resolver"
+    semver-increment: "major"
+    when:
+      label: "major"
+  - type: "version-resolver"
+    semver-increment: "minor"
+    when:
+      label: "minor"
+  - type: "version-resolver"
+    semver-increment: "patch"
+    when:
+      label: "patch"
+  - type: "version-resolver"
+    semver-increment: "patch"
 change-template: "- $TITLE ([#$NUMBER]($URL)) (**@$AUTHOR**)"
 change-title-escapes: '\<*_&'
-exclude-labels:
-  - "skip-changelog"
-  - "backport"
-  - "release-prep"
-version-resolver:
-  major:
-    labels:
-      - "major"
-  minor:
-    labels:
-      - "minor"
-  patch:
-    labels:
-      - "patch"
-  default: patch
 
 template: |
   ## 👀 What Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#142)._
 ### Changed
 
 - 🔧 Migrate Release Drafter configuration to the current category schema and
-  group CI and tooling changes together ([**@burgholzer**])
+  group CI and tooling changes together ([#386]) ([**@burgholzer**])
 - 📝 Require LLVM/MLIR for `c++-mlir-python` projects and remove the obsolete
   instructions for disabling MLIR ([#384]) ([**@burgholzer**])
 - 🤖 Require disclosure of AI assistance in the PR description and recommend
@@ -316,6 +316,7 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#110)._
 
 <!-- PR links -->
 
+[#386]: https://github.com/munich-quantum-toolkit/templates/pull/386
 [#384]: https://github.com/munich-quantum-toolkit/templates/pull/384
 [#383]: https://github.com/munich-quantum-toolkit/templates/pull/383
 [#377]: https://github.com/munich-quantum-toolkit/templates/pull/377

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#142)._
 
 ### Changed
 
+- 🔧 Migrate Release Drafter configuration to the current category schema and
+  group CI and tooling changes together ([**@burgholzer**])
 - 📝 Require LLVM/MLIR for `c++-mlir-python` projects and remove the obsolete
   instructions for disabling MLIR ([#384]) ([**@burgholzer**])
 - 🤖 Require disclosure of AI assistance in the PR description and recommend

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -8,6 +8,10 @@ of changes, including minor and patch releases, please refer to the
 
 ## [1.4.2]
 
+Release Drafter configuration now uses category-based matching, exclusion, and
+version resolution. The CI category is now named `CI & Tooling` and matches both
+the `continuous integration` and `tooling` labels.
+
 The installation guide for `c++-mlir-python` projects now treats LLVM/MLIR as a
 mandatory source-build dependency. It no longer documents a generated
 `BUILD_MQT_<NAME>_MLIR` CMake option for disabling MLIR.

--- a/defaults/release_drafter_categories.json
+++ b/defaults/release_drafter_categories.json
@@ -7,7 +7,7 @@
   ],
   "🐛 Bug Fixes": ["bug", "fix"],
   "📄 Documentation": ["documentation"],
-  "🤖 CI": ["continuous integration"],
+  "🤖 CI & Tooling": ["continuous integration", "tooling"],
   "📦 Packaging": ["packaging"],
   "🧹 Code Quality": ["code quality"],
   "⬆️ Dependencies": [

--- a/templates/release-drafter.yml.in
+++ b/templates/release-drafter.yml.in
@@ -9,28 +9,34 @@ categories:
     {%- if title == "⬆️ Dependencies" %}
     collapse-after: 5
     {%- endif %}
-    labels:
-      {%- for label in labels %}
-      - "{{ label }}"
-      {%- endfor %}
+    when:
+      labels:
+        {%- for label in labels %}
+        - "{{ label }}"
+        {%- endfor %}
   {%- endfor %}
+  - type: "pre-exclude"
+    when:
+      labels:
+        - "skip-changelog"
+        - "backport"
+        - "release-prep"
+  - type: "version-resolver"
+    semver-increment: "major"
+    when:
+      label: "major"
+  - type: "version-resolver"
+    semver-increment: "minor"
+    when:
+      label: "minor"
+  - type: "version-resolver"
+    semver-increment: "patch"
+    when:
+      label: "patch"
+  - type: "version-resolver"
+    semver-increment: "patch"
 change-template: "- $TITLE ([#$NUMBER]($URL)) (**@$AUTHOR**)"
 change-title-escapes: '\<*_&'
-exclude-labels:
-  - "skip-changelog"
-  - "backport"
-  - "release-prep"
-version-resolver:
-  major:
-    labels:
-      - "major"
-  minor:
-    labels:
-      - "minor"
-  patch:
-    labels:
-      - "patch"
-  default: patch
 
 template: |
   {% if has_changelog_and_upgrade_guide -%}

--- a/tests/test_render_templates.py
+++ b/tests/test_render_templates.py
@@ -83,6 +83,20 @@ def _check_ai_guidance(target_dir: Path, *, has_agents_md: bool) -> None:
         assert "production source or tool directories" in agents_content
 
 
+def _check_release_drafter(target_dir: Path) -> None:
+    """Check that Release Drafter uses the current category schema."""
+    content = (target_dir / ".github" / "release-drafter.yml").read_text()
+    assert 'title: "🤖 CI & Tooling"' in content
+    assert '"continuous integration"' in content
+    assert '"tooling"' in content
+    assert "exclude-labels:" not in content
+    assert "\n    label:" not in content
+    assert "\n    labels:" not in content
+    assert "\nversion-resolver:" not in content
+    assert content.count('type: "pre-exclude"') == 1
+    assert content.count('type: "version-resolver"') == 4
+
+
 @pytest.mark.parametrize("project_type", ["c++-python", "pure-python", "c++-mlir-python"])
 @pytest.mark.parametrize("has_changelog_and_upgrade_guide", [True, False])
 def test_non_other(temp_dir: Path, project_type: str, *, has_changelog_and_upgrade_guide: bool) -> None:
@@ -127,6 +141,7 @@ def test_non_other(temp_dir: Path, project_type: str, *, has_changelog_and_upgra
     ]
     _check_files(files)
     _check_ai_guidance(temp_dir, has_agents_md=True)
+    _check_release_drafter(temp_dir)
 
     installation = " ".join((temp_dir / "docs" / "installation.md").read_text().split())
     if project_type == "c++-mlir-python":
@@ -173,6 +188,7 @@ def test_other(temp_dir: Path) -> None:
         temp_dir / "docs" / "lit_header.bib",
     ]
     _check_files(files)
+    _check_release_drafter(temp_dir)
 
 
 def test_ai_usage_renders_with_contribution_guide_only(temp_dir: Path) -> None:


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Remove all 11 Release Drafter v7.6.0 deprecation warnings reported by [run 30479938352](https://github.com/munich-quantum-toolkit/templates/actions/runs/30479938352/job/90671071287) while preserving the existing categorization, exclusions, and version-resolution behavior.

This PR:

- moves changelog category labels under `when`;
- replaces `exclude-labels` with a `pre-exclude` category;
- replaces the legacy `version-resolver` label blocks with typed resolver categories and an explicit patch fallback;
- applies the migration to the authoritative template and regenerates this repository's configuration;
- renames `🤖 CI` to `🤖 CI & Tooling` and adds the `tooling` label; and
- includes the change in the unpublished v1.4.2 release notes and upgrade guide.

## Validation

- Validated `.github/release-drafter.yml` against the exact schema from the pinned Release Drafter v7.6.0 commit.
- `uv run --group test python -m pytest` (9 passed)
- `uv run prek run --all-files`
- Independent semantic verification of matching, exclusion, fallback-version, generated-file, and release-version behavior.

The Release Drafter workflow only runs after pushes to `main`; the post-merge run remains the final check that GitHub emits no warnings.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/templates/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.