### PR TITLE
⬆️ Update MQT Templates to `v1.4.2`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,5 +29,5 @@ This checklist serves as a reminder of a couple of things that ensure your pull 
 
 - [ ] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/templates/blob/main/docs/ai_usage.md).
 - [ ] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
-- [ ] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
+- [ ] I have disclosed AI assistance in the PR description.
 - [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.

--- a/.github/workflows/templating.yml
+++ b/.github/workflows/templating.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-      - uses: munich-quantum-toolkit/templates@02460c7352d8d8a13414c9c082f062b33c3c5ecb # v1.4.1
+      - uses: munich-quantum-toolkit/templates@d0c5adb86d19a5095f871cb6184cfdab298e943c # v1.4.2
         with:
           token: ${{ steps.create-token.outputs.token }}
           name: Templates

--- a/docs/ai_usage.md
+++ b/docs/ai_usage.md
@@ -76,14 +76,16 @@ beginning of the edited field.
 Transparency helps the community understand the role of these tools and develop
 best practices.
 
-**You must disclose AI assistance.** This helps us understand how the tools are
-being used and identify potential issues. Disclose it in the following ways:
+**AI assistance must be disclosed in the PR description.** This helps reviewers
+understand how the tools were used and where human verification was applied.
 
-- **Commit Messages**: Add a trailer to your commit message in the form
-  `Assisted-by: [Model Name] via [Tool Name]` (example:
-  `Assisted-by: Claude Sonnet 4.6 via GitHub Copilot`)
-- **Public issue and pull request text**: Use the visible disclosure required in
-  the [communication policy](#3-communication).
+- **PR Description**: Briefly state how AI tools materially assisted the
+  contribution. If an agent authored or edited the description, use the visible
+  disclosure required in the [communication policy](#3-communication).
+- **Commit Messages**: We recommend adding an
+  `Assisted-by: [Model Name] via [Tool Name]` trailer to commits prepared with
+  AI assistance. For example:
+  `Assisted-by: Claude Sonnet 4.6 via GitHub Copilot`.
 
 ### 5. Licensing and Copyright
 


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Roll out MQT Templates v1.4.2 to the templates repository itself before updating the remaining consumers.

This PR:

- pins the templating workflow to the exact signed v1.4.2 release commit `d0c5adb86d19a5095f871cb6184cfdab298e943c`; and
- applies the two generated v1.4.2 AI-policy updates to the pull request template and AI usage guide.

The released v1.4.2 renderer leaves `.github/release-drafter.yml` unchanged, preserving the current category schema and `CI & Tooling` category. This supersedes #387, which was generated by v1.4.1 and would revert that migration.

## Validation

- `uv run --group test python -m pytest` (9 passed)
- `uv run prek run --all-files`
- Independent render from exact release commit; both generated files are byte-identical.
- Independent verification that `.github/release-drafter.yml` remains byte-identical to v1.4.2.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/templates/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.