### PR TITLE
🤖 Improve prose, terminology, and test guidance in AGENTS.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ releases may include breaking changes.
 
 ### Changed
 
-- 📝 Improve AGENTS.md prose, terminology, and test guidance ([#399])
+- 🤖 Improve prose, terminology, and test guidance in AGENTS.md ([#399])
   ([**@denialhaag**])
 
 ## [1.4.2] - 2026-07-29
@@ -21,21 +21,13 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#142)._
 
 ### Changed
 
-- 🔧 Migrate Release Drafter configuration to the current category schema and
+- 🔧 Migrate Release Drafter configuration to the current category schema, and
   group CI and tooling changes together ([#386]) ([**@burgholzer**])
 - 📝 Require LLVM/MLIR for `c++-mlir-python` projects and remove the obsolete
   instructions for disabling MLIR ([#384]) ([**@burgholzer**])
 - 🤖 Require disclosure of AI assistance in the PR description and recommend
   commit-level `Assisted-by` attribution ([#383]) ([**@burgholzer**])
-- 🧪 Keep tests in their respective test trees, organized by owning component,
-  and avoid promoting optional production tools into default builds solely for
-  subprocess testing ([#383]) ([**@burgholzer**])
-
-### Fixed
-
-- 🐍 Account for the TOML 1.0-normalized `pyproject.toml` and preserved original
-  emitted by `uv_build` 0.12 in source-distribution checks ([#383])
-  ([**@burgholzer**])
+- 🤖 Improve test guidance in AGENTS.md ([#383]) ([**@burgholzer**])
 
 ## [1.4.1] - 2026-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ releases may include breaking changes.
 
 ## [Unreleased]
 
+### Changed
+
+- 📝 Improve AGENTS.md prose, terminology, and test guidance ([#399])
+  ([**@denialhaag**])
+
 ## [1.4.2] - 2026-07-29
 
 _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#142)._
@@ -316,6 +321,7 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#110)._
 
 <!-- PR links -->
 
+[#399]: https://github.com/munich-quantum-toolkit/templates/pull/399
 [#386]: https://github.com/munich-quantum-toolkit/templates/pull/386
 [#384]: https://github.com/munich-quantum-toolkit/templates/pull/384
 [#383]: https://github.com/munich-quantum-toolkit/templates/pull/383

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -106,6 +106,9 @@
   `ty`, formatting, and metadata checks). All hooks must pass before submitting.
 - MUST add or update tests for every code change, even if not explicitly
   requested.
+- MUST write tests that protect intended behavior or reproduce a concrete
+  regression. NEVER test provisional implementation choices that are not part of
+  the supported contract.
 - MUST place tests in the repository's corresponding test tree, organized by the
   component that owns the behavior. NEVER place tests or test fixtures in
   production source or tool directories. Reserve tool- or CLI-level subprocess
@@ -114,6 +117,37 @@
   build; avoid promoting an otherwise optional production tool into the default
   build solely for subprocess testing.
 - MUST follow existing code style by checking neighboring files for patterns.
+- MUST write code comments, documentation, tests, changelog entries, and public
+  text for the final design. NEVER preserve prompts, review chronology, former
+  names, or abandoned approaches unless they remain necessary user-facing
+  context.
+- MUST apply
+  [Orwell's six rules for writing](https://www.orwellfoundation.com/the-orwell-foundation/orwell/essays-and-other-works/politics-and-the-english-language/)
+  to every category of prose, including reasoning, descriptions, commit
+  messages, documentation, docstrings, comments, test text, diagnostics, and
+  handoffs:
+
+  1. Do not use a familiar metaphor, simile, or other figure of speech.
+  2. Use a short word when it has the same meaning as a long word.
+  3. Remove every word that does not add meaning.
+  4. Use active voice when possible.
+  5. Use everyday English instead of a foreign phrase, scientific word, or
+     jargon term when this does not reduce precision.
+  6. Break a rule before it makes the text unclear, incorrect, or needlessly
+     difficult to read.
+
+- MUST apply the relevant principles of
+  [ASD-STE100 Simplified Technical English](https://www.asd-ste100.org/): use
+  short, direct sentences; give each sentence one main idea; use one term for
+  one meaning; and use explicit nouns instead of vague pronouns. These are
+  mandatory style rules, not a claim of formal ASD-STE100 compliance.
+- MUST base terminology and phrasing on existing usage in the repository and on
+  established precedents in the communities the repository draws from. Use the
+  established term that most precisely matches the concept. If communities use
+  different terms, explain the mapping once. NEVER invent synonyms for variety.
+- MUST remove obsolete scaffolding and diagnostic suppressions before handoff.
+  Keep a workaround or suppression only when it is still necessary, scope it as
+  narrowly as possible, and document the technical reason.
 {%- if has_changelog_and_upgrade_guide %}
 - MUST update `CHANGELOG.md` and `UPGRADING.md` when changes are user-facing,
   breaking, or otherwise noteworthy.


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

This replicates https://github.com/munich-quantum-toolkit/core/pull/2072 in the shared AGENTS.md template. It adds six rules, adapted to the template's MUST/NEVER/PREFER style and listed here in the order they appear in the file:

- Test intended behavior and concrete regressions instead of provisional implementation choices.
- Write comments, documentation, tests, changelog entries, and public text for the final design, and drop prompts, review chronology, former names, and abandoned approaches that users no longer need.
- Apply [Orwell's six rules for writing](https://www.orwellfoundation.com/the-orwell-foundation/orwell/essays-and-other-works/politics-and-the-english-language/) to every category of prose, including commit messages, documentation, docstrings, comments, test text, and diagnostics.
- Apply the relevant principles of [ASD-STE100 Simplified Technical English](https://www.asd-ste100.org/): short, direct sentences, one idea per sentence, one term per meaning, and explicit nouns. These are style rules, not a claim of formal compliance.
- Base terminology on existing usage in the repository and on established precedents in the communities the repository draws from, instead of inventing synonyms.
- Remove obsolete scaffolding and diagnostic suppressions before handoff, and document any workaround that is still necessary.

## AI notice

This PR and its contents were created with the assistance of Opus 5 via Claude Code.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/templates/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.

