### PR TITLE
📝 Remove mention of extensive tests from contribution guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ releases may include breaking changes.
 
 ### Changed
 
+- 📝 Remove mention of extensive tests from contribution guide ([#404])
+  ([**@denialhaag**])
 - 🤖 Improve prose, terminology, and test guidance in AGENTS.md ([#399])
   ([**@denialhaag**])
 
@@ -313,6 +315,7 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#110)._
 
 <!-- PR links -->
 
+[#404]: https://github.com/munich-quantum-toolkit/templates/pull/404
 [#399]: https://github.com/munich-quantum-toolkit/templates/pull/399
 [#386]: https://github.com/munich-quantum-toolkit/templates/pull/386
 [#384]: https://github.com/munich-quantum-toolkit/templates/pull/384

--- a/templates/docs_contributing.md
+++ b/templates/docs_contributing.md
@@ -217,10 +217,8 @@ systems and compilers:
 To access the latest build logs, visit the
 [GitHub Actions page](https://github.com/{{organization}}/{{repository}}/actions/workflows/ci.yml).
 
-Additionally, we regularly run extensive tests with an even wider matrix of
-compilers and operating systems. We are not aware of any issues with other
-compilers or operating systems. If you encounter any problems, please
-[open an issue][issues] and let us know.
+We are not aware of any issues with other compilers or operating systems. If you
+encounter any problems, please [open an issue][issues] and let us know.
 
 ### Configure and Build
 


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

This PR removes the sentence about regularly running extensive tests on a wider matrix of compilers and operating systems from the contribution guide.

The extensive CI jobs it referred to are being removed (munich-quantum-toolkit/core#2083, munich-quantum-toolkit/ddsim#964, munich-quantum-toolkit/qcec#1029, and munich-quantum-toolkit/qmap#1114).

## AI notice

This PR and its contents were created with the assistance of Opus 5 via Claude Code.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/templates/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
