### PR TITLE
📝 Document Python 3.11+ and Apple silicon support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ releases may include breaking changes.
 
 - ✨ Synchronize `.gitignore` file ([#415]) ([**@denialhaag**])
 
+### Changed
+
+- 📝 Document Python 3.11+ and Apple silicon support ([#416])
+  ([**@denialhaag**])
+
 ## [1.4.3] - 2026-08-26
 
 ### Added
@@ -331,6 +336,7 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#110)._
 
 <!-- PR links -->
 
+[#416]: https://github.com/munich-quantum-toolkit/templates/pull/416
 [#415]: https://github.com/munich-quantum-toolkit/templates/pull/415
 [#411]: https://github.com/munich-quantum-toolkit/templates/pull/411
 [#410]: https://github.com/munich-quantum-toolkit/templates/pull/410

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -73,7 +73,7 @@
 
 ### Python
 
-- Python 3.10+
+- Python 3.11+
 {%- if project_type in ["c++-python", "c++-mlir-python"] %}
 - Stable ABI wheels for 3.12+; free-threading support for 3.14+
 - `scikit-build-core` as build backend

--- a/templates/docs_contributing.md
+++ b/templates/docs_contributing.md
@@ -209,7 +209,6 @@ systems and compilers:
 - {code}`ubuntu-24.04-arm`: {code}`Release` build using {code}`gcc`
 - {code}`macos-26`: {code}`Release` and {code}`Debug` builds using
   {code}`AppleClang`
-- {code}`macos-26-intel`: {code}`Release` build using {code}`AppleClang`
 - {code}`windows-2025`: {code}`Release` and {code}`Debug` builds using
   {code}`msvc`
 - {code}`windows-11-arm`: {code}`Release` build using {code}`msvc`


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

Update the shared templates to document Python 3.11 or newer in generated agent instructions and remove `macos-26-intel` from the CI matrix in generated contribution guides. These changes accurately reflect how MQT repositories are developed and tested.

## AI notice

This PR and its contents were created with the assistance of GPT-5.6 Sol via Codex.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/templates/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
