### PR TITLE
📝 Document nanobind 3 split-mode wheels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ releases may include breaking changes.
 
 ### Changed
 
+- 📝 Document `nanobind` 3 split-mode Stable ABI wheels ([#423])
+  ([**@denialhaag**])
 - 📝 Document LLVM 23.1 for MLIR projects ([#422]) ([**@denialhaag**])
 - 📝 Document Python 3.11+ and Apple silicon support ([#416])
   ([**@denialhaag**])
@@ -337,6 +339,7 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#110)._
 
 <!-- PR links -->
 
+[#423]: https://github.com/munich-quantum-toolkit/templates/pull/423
 [#422]: https://github.com/munich-quantum-toolkit/templates/pull/422
 [#417]: https://github.com/munich-quantum-toolkit/templates/pull/417
 [#416]: https://github.com/munich-quantum-toolkit/templates/pull/416

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,7 @@ releases may include breaking changes.
 
 ### Changed
 
-- 📝 Document `nanobind` 3 split-mode Stable ABI wheels ([#423])
-  ([**@denialhaag**])
+- 📝 Document `nanobind` 3 split-mode wheels ([#423]) ([**@denialhaag**])
 - 📝 Document LLVM 23.1 for MLIR projects ([#422]) ([**@denialhaag**])
 - 📝 Document Python 3.11+ and Apple silicon support ([#416])
   ([**@denialhaag**])

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -75,7 +75,8 @@
 
 - Python 3.11+
 {%- if project_type in ["c++-python", "c++-mlir-python"] %}
-- Stable ABI wheels for 3.12+; free-threading support for 3.14+
+- Split-mode Stable ABI wheels: `cp311-abi3` for GIL-enabled CPython 3.11+ and
+  `cp315-abi3t` for free-threaded CPython 3.15+
 - `scikit-build-core` as build backend
 - `nanobind` for bindings
 {%- endif %}

--- a/templates/tooling.md
+++ b/templates/tooling.md
@@ -27,15 +27,14 @@ to understand the project's ecosystem.
 | **scikit-build-core** | Build backend for Python package.                              | [Documentation](https://scikit-build-core.readthedocs.io/en/latest/).                                                                     |
 | **cibuildwheel**      | Builds wheels for all supported platforms and Python versions. | [Documentation](https://cibuildwheel.pypa.io/en/stable/). Configured in {code}`pyproject.toml`.                                           |
 
-By using `nanobind`, we can take advantage of the
-[Stable ABI](https://docs.python.org/3/c-api/stable.html) for Python 3.12+. This
-means that, starting from Python 3.12, we only need to build one wheel per
-platform, which can be used across all Python 3.12+ versions. We still build
-separate wheels for older supported Python versions.
+Projects use `nanobind`'s split mode to build one `cp311-abi3` wheel per
+platform for GIL-enabled CPython 3.11 and newer. The `nanobind-backend` package
+supplies the interpreter-specific runtime.
 
-Additionally, we support the free-threading version of Python that is no longer
-marked experimental as of Python 3.14. The corresponding wheels are built
-separately since there is no stable ABI for free-threading Python yet.
+Free-threaded CPython uses the separate
+[Stable ABI for Free-Threaded Builds (`abi3t`)](https://peps.python.org/pep-0803/).
+One `cp315-abi3t` wheel per platform supports free-threaded CPython 3.15 and
+newer.
 
 {%- if project_type == "c++-mlir-python" %}
 


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Document how C++/Python projects use `nanobind`'s split mode to build Stable ABI wheels. For each platform, one `cp311-abi3` wheel supports GIL-enabled CPython 3.11 and newer, and one `cp315-abi3t` wheel supports free-threaded CPython 3.15 and newer. The tooling guide links to [PEP 803](https://peps.python.org/pep-0803/) for `abi3t` and explains that `nanobind-backend` supplies the interpreter-specific runtime.

Update the matching AGENTS guidance so generated project instructions use the same wheel policy.

## AI notice

This PR and its contents were created with the assistance of GPT-5.6 Sol via Codex.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/templates/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
