### PR TITLE
🐛 Keep release drafts branch-specific

### DIFF
--- a/templates/release-drafter.yml.in
+++ b/templates/release-drafter.yml.in
@@ -3,6 +3,7 @@
 
 name-template: "MQT {{name}} $RESOLVED_VERSION Release"
 tag-template: "v$RESOLVED_VERSION"
+filter-by-commitish: true
 categories:
   {%- for title, labels in release_drafter_categories.items() %}
   - title: "{{ title }}"
@@ -35,7 +36,7 @@ categories:
       label: "patch"
   - type: "version-resolver"
     semver-increment: "patch"
-change-template: "- $TITLE ([#$NUMBER]($URL)) (**@$AUTHOR**)"
+change-template: "- $TITLE (#$NUMBER) (@$AUTHOR)"
 change-title-escapes: '\<*_&'
 
 template: |

--- a/tests/test_render_templates.py
+++ b/tests/test_render_templates.py
@@ -89,6 +89,8 @@ def _check_release_drafter(target_dir: Path) -> None:
     assert 'title: "🤖 CI & Tooling"' in content
     assert '"continuous integration"' in content
     assert '"tooling"' in content
+    assert "filter-by-commitish: true" in content
+    assert 'change-template: "- $TITLE (#$NUMBER) (@$AUTHOR)"' in content
     assert "exclude-labels:" not in content
     assert "\n    label:" not in content
     assert "\n    labels:" not in content


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Keep Release Drafter drafts and comparison baselines scoped to their target branch. This prevents maintenance-branch releases from replacing the `main` draft.

Use GitHub's native pull request and user autolinks in change entries. This reduces the failing MQT Core release body from approximately 133,000 characters to approximately 95,000 characters without removing titles or authors.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/templates/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.

Validation: `uv run --group test python -m pytest tests/test_render_templates.py` (9 passed); `uv run prek run --all-files` (passed).
