### PR TITLE
⬆️ Update templating action to v1.5.0

### DIFF
--- a/.github/workflows/templating.yml
+++ b/.github/workflows/templating.yml
@@ -28,7 +28,7 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           permission-contents: write # Needed to push the templating branch
           permission-pull-requests: write # Needed to open the templating pull request
-      - uses: munich-quantum-toolkit/templates@f87a5f152d33b64e3cc4fad41c402bf7ce892f5d # v1.4.3
+      - uses: munich-quantum-toolkit/templates@8caeb0bd8d0e2ebf906e7c3a826c06f72844a83b # v1.5.0
         with:
           token: ${{ steps.create-token.outputs.token }}
           name: Templates

--- a/.gitignore
+++ b/.gitignore
@@ -1,129 +1,75 @@
-# Byte-compiled / optimized / DLL files
+# Python
 __pycache__/
 *.py[cod]
 *$py.class
-
-# C extensions
 *.so
 
-# Distribution / packaging
-.Python
-build/
-develop-eggs/
-dist/
-downloads/
-eggs/
+# Packaging
+/build/
+/dist/
 .eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-wheels/
-share/python-wheels/
-*.egg-info/
-.installed.cfg
 *.egg
-MANIFEST
+*.egg-info/
+/_skbuild/
+/wheelhouse/
 
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
-
-# Unit test / coverage reports
-htmlcov/
-.tox/
-.nox/
+# Testing
 .coverage
 .coverage.*
-.cache
-nosetests.xml
-coverage.xml
-*.cover
-*.py,cover
 .hypothesis/
+.nox/
 .pytest_cache/
-cover/
+.tox/
+*.cover
+*.profraw
+coverage.xml
+htmlcov/
 
-# Translations
-*.mo
-*.pot
-
-# Django stuff
-*.log
-local_settings.py
-db.sqlite3
-db.sqlite3-journal
-
-# Flask stuff
-instance/
-.webassets-cache
-
-# Scrapy stuff
-.scrapy
-
-# Sphinx documentation
+# Documentation
 docs/_build/
-
-# PyBuilder
-.pybuilder/
-target/
-
-# Jupyter Notebook
-.ipynb_checkpoints
-
-# IPython
-profile_default/
-ipython_config.py
-
-# PEP 582
-__pypackages__/
-
-# Celery stuff
-celerybeat-schedule
-celerybeat.pid
-
-# SageMath parsed files
-*.sage.py
+docs/**/build/
+docs/api/
 
 # Environments
 .env
-.venv
+.env.*
+!.env.example
+!.env.*.example
+.venv/
 env/
 venv/
-ENV/
-env.bak/
-venv.bak/
 
-# Spyder project settings
-.spyderproject
-.spyproject
-
-# Rope project settings
-.ropeproject
-
-# mkdocs documentation
-/site
-
-# mypy
+# Tool caches
+.cache/
 .mypy_cache/
-.dmypy.json
-dmypy.json
-
-# Pyre type checker
 .pyre/
-
-# pytype static type analyzer
 .pytype/
+.ruff_cache/
+.rumdl_cache/
 
-# Cython debug symbols
-cython_debug/
+# Jupyter
+.ipynb_checkpoints/
 
-# setuptools_scm
+# Versioning
+python/**/_version.py
 src/**/_version.py
+
+# Editors
+.idea/
+.vs/
+.vscode/
+*.swp
+*~
+
+# Claude
+.claude/
+CLAUDE.md
+
+# Operating systems
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+Thumbs.db
+ehthumbs.db


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

Update the [munich-quantum-toolkit/templates](https://github.com/munich-quantum-toolkit/templates) action to v1.5.0. Align the local `.gitignore` with the shared base; no repository-specific ignore rules are required. The action does not synchronize `.gitignore` for `project-type: other`, so the file remains manually maintained.

## AI notice

This PR and its contents were created with the assistance of GPT-5.6 Sol via Codex.
