### PR TITLE
🔖 Prepare release of `v1.5.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ releases may include breaking changes.
 
 ## [Unreleased]
 
+## [1.5.1] - 2026-09-06
+
+_If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#151)._
+
 ### Added
 
 - ✨ Synchronize `.gitignore` for repositories with `project-type: other`
@@ -329,7 +333,8 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#110)._
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/munich-quantum-toolkit/templates/compare/v1.5.0...HEAD
+[unreleased]: https://github.com/munich-quantum-toolkit/templates/compare/v1.5.1...HEAD
+[1.5.1]: https://github.com/munich-quantum-toolkit/templates/releases/tag/v1.5.1
 [1.5.0]: https://github.com/munich-quantum-toolkit/templates/releases/tag/v1.5.0
 [1.4.3]: https://github.com/munich-quantum-toolkit/templates/releases/tag/v1.4.3
 [1.4.2]: https://github.com/munich-quantum-toolkit/templates/releases/tag/v1.4.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ releases may include breaking changes.
 - ✨ Synchronize `.gitignore` for repositories with `project-type: other`
   ([#427]) ([**@denialhaag**])
 
+### Changed
+
+- 💥 Require CMake 3.28 or newer for rendered C++ project guidance ([#433])
+  ([**@burgholzer**])
+
 ## [1.5.0] - 2026-09-03
 
 _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#150)._
@@ -353,6 +358,7 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#110)._
 
 <!-- PR links -->
 
+[#433]: https://github.com/munich-quantum-toolkit/templates/pull/433
 [#427]: https://github.com/munich-quantum-toolkit/templates/pull/427
 [#424]: https://github.com/munich-quantum-toolkit/templates/pull/424
 [#423]: https://github.com/munich-quantum-toolkit/templates/pull/423

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,8 @@ of changes, including minor and patch releases, please refer to the
 
 ## [Unreleased]
 
+## [1.5.1]
+
 Rendered guidance for C++ projects now requires CMake 3.28 or newer. Upgrade
 CMake before applying the updated installation, contribution, or agent guide.
 
@@ -166,7 +168,8 @@ jobs:
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/munich-quantum-toolkit/templates/compare/v1.5.0...HEAD
+[unreleased]: https://github.com/munich-quantum-toolkit/templates/compare/v1.5.1...HEAD
+[1.5.1]: https://github.com/munich-quantum-toolkit/templates/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/munich-quantum-toolkit/templates/compare/v1.4.3...v1.5.0
 [1.4.2]: https://github.com/munich-quantum-toolkit/templates/compare/v1.4.1...v1.4.2
 [1.4.0]: https://github.com/munich-quantum-toolkit/templates/compare/v1.3.3...v1.4.0

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,9 @@ of changes, including minor and patch releases, please refer to the
 
 ## [Unreleased]
 
+Rendered guidance for C++ projects now requires CMake 3.28 or newer. Upgrade
+CMake before applying the updated installation, contribution, or agent guide.
+
 The `synchronize-gitignore` flag remains enabled by default and now also applies
 to repositories with `project-type: other`. Repositories with project-specific
 ignore rules must explicitly set `synchronize-gitignore: false`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "uv_build"
 
 [project]
 name = "mqt-templates"
-version = "1.5.0"
+version = "1.5.1"
 authors = [
   { name="Daniel Haag", email = "daniel.haag@tum.de" },
   { name="Lukas Burgholzer", email = "burgholzer@me.com" },

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -57,7 +57,7 @@
 - Targets Linux (glibc 2.28+), macOS (11.0+), and Windows on x86_64 and arm64
   architectures
 - C++20
-- CMake 3.24+
+- CMake 3.28+
 - `FetchContent` for dependency management (configured in
   `cmake/ExternalDependencies.cmake`)
 - `clang-format` and `clang-tidy` for formatting/linting (see `.clang-format`

--- a/templates/docs_contributing.md
+++ b/templates/docs_contributing.md
@@ -200,7 +200,7 @@ instructions on how to set up your development environment.
 
 Building the project requires a C++20-capable
 [C++ compiler](https://en.wikipedia.org/wiki/List_of_compilers#C++_compilers)
-and [CMake](https://cmake.org/) 3.24 or newer. As of August 2025, our CI
+and [CMake](https://cmake.org/) 3.28 or newer. As of August 2025, our CI
 pipeline on GitHub continuously tests the library across the following matrix of
 systems and compilers:
 

--- a/templates/installation.md
+++ b/templates/installation.md
@@ -123,7 +123,7 @@ pip install mqt.{{repository}} --no-binary mqt.{{repository}}
 
 This requires a C++20-capable
 [C++ compiler](https://en.wikipedia.org/wiki/List_of_compilers#C++_compilers)
-and [CMake](https://cmake.org/) 3.24 or newer.
+and [CMake](https://cmake.org/) 3.28 or newer.
 
 {%- endif %}
 

--- a/tests/test_render_templates.py
+++ b/tests/test_render_templates.py
@@ -147,6 +147,9 @@ def test_non_other(temp_dir: Path, project_type: str, *, has_changelog_and_upgra
     _check_ai_guidance(temp_dir, has_agents_md=True)
     _check_release_drafter(temp_dir)
 
+    agents = " ".join((temp_dir / "AGENTS.md").read_text().split())
+    contributing = " ".join((temp_dir / "docs" / "contributing.md").read_text().split())
+
     installation = " ".join((temp_dir / "docs" / "installation.md").read_text().split())
     if project_type == "c++-mlir-python":
         assert "Install LLVM/MLIR as described below. It is required to build MQT Test from source." in installation
@@ -154,6 +157,11 @@ def test_non_other(temp_dir: Path, project_type: str, *, has_changelog_and_upgra
         assert "BUILD_MQT_TEST_MLIR" not in installation
     else:
         assert "Setting Up MLIR" not in installation
+
+    if project_type != "pure-python":
+        assert "CMake 3.28+" in agents
+        assert "[CMake](https://cmake.org/) 3.28 or newer" in contributing
+        assert "[CMake](https://cmake.org/) 3.28 or newer" in installation
 
 
 def test_other(temp_dir: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -86,7 +86,7 @@ wheels = [
 
 [[package]]
 name = "mqt-templates"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

This PR prepares the release of `v1.5.1`, dated 2026-09-06, and makes the CMake 3.28 template migration directly deployable.

It raises rendered C++ project guidance from CMake 3.24 to 3.28, adds rendering assertions, includes the `.gitignore` synchronization change from #427, updates the package and lockfile versions, and finalizes the changelog and upgrade guide.

AI assistance: Codex implemented, reviewed, and locally validated the scoped changes under explicit authorization.

Validation: `uv run --group test python -m pytest` (9 passed); `uv run prek run --all-files` (passed).

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/templates/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.