### PR TITLE
📝 Fix documentation build guidance

### DIFF
--- a/templates/docs_contributing.md
+++ b/templates/docs_contributing.md
@@ -399,10 +399,14 @@ refactor.
 For some tips on how to write good Doxygen comments, see the
 [Doxygen Manual](https://www.doxygen.nl/manual/docblocks.html).
 
+{% if repository == "core" %}
+The C++ API reference uses native Doxygen HTML linked from Sphinx.
+{% else %}
 The C++ API documentation is integrated into the overall documentation that we
 host on ReadTheDocs using the
-[breathe](https://breathe.readthedocs.io/en/latest/) extension for Sphinx. See
-{ref}`working-on-documentation` for more information on how to build the
+[breathe](https://breathe.readthedocs.io/en/latest/) extension for Sphinx.
+{% endif %}
+See {ref}`working-on-documentation` for more information on how to build the
 documentation.
 
 {%- endif %}
@@ -607,38 +611,37 @@ The documentation is written in
 Markdown) and built using [Sphinx](https://www.sphinx-doc.org/en/master/). The
 documentation source files can be found in the {code}`docs/` directory.
 
-On top of the API documentation, we provide a set of tutorials and examples that
-demonstrate how to use the library. These are written in Markdown using
-[myst-nb](https://myst-nb.readthedocs.io/en/latest/), which allows executing
-Python code blocks in the documentation. The code blocks are executed during the
-documentation build process, and the output is included in the documentation.
-This allows us to provide up-to-date examples and tutorials that are guaranteed
-to work with the latest version of the library.
+Tutorials use [MyST-NB](https://myst-nb.readthedocs.io/) Markdown notebooks.
+Only `{code-cell}` blocks in notebook pages execute; ordinary code fences are
+illustrative. Keep required setup visible, show useful output, and assert the
+behavior that each example demonstrates. Use local simulation for executable
+examples; leave credentials and remote-device deployment as configuration
+recipes.
 
-You can build the documentation using the {code}`nox` session {code}`docs`.
-
-```console
-nox -s docs
-```
-
-This will install all dependencies for building the documentation in an isolated
-environment, build the Python package, and then build the documentation. It will
-then host the documentation on a local web server for you to view.
-
-:::{note}
-
-If you do not want to use {code}`nox`, you can also build the documentation
-directly using {code}`sphinx-build`. This requires that you have the project and
-its documentation dependencies installed in your virtual environment (e.g., by
-running {code}`uv sync`).
+Use the documentation session to install Python dependencies, build the package
+and generated references, and render the examples:
 
 ```console
-sphinx-build -b html docs/ docs/_build
+uvx nox --non-interactive -s docs
 ```
 
-The docs can then be found in the {code}`docs/_build` directory.
+Install the project's native build requirements first. C++ API generation needs
+Doxygen; DD visualizations also need the Graphviz `dot` executable. The session
+manages Python packages, not these system tools.
+{% if project_type == "c++-mlir-python" %}
+LLVM/MLIR must also be installed as described in {ref}`setting-up-mlir`.
+{% endif %}
+{% if repository == "core" %}
+See {doc}`development` for Core's documentation validation and local-device
+execution contract.
+{% endif %}
 
-:::
+Omit `--non-interactive` to serve the documentation while editing. To check
+external links, run:
+
+```console
+uvx nox --non-interactive -s docs -- -b linkcheck
+```
 
 ## Tips for Development
 

--- a/templates/installation.md
+++ b/templates/installation.md
@@ -317,6 +317,13 @@ guidelines and workflows, see {doc}`contributing`.
 
    Now you can make your changes locally.
 
+{%- if project_type == "c++-mlir-python" %}
+
+Before building the package, install LLVM/MLIR as described in
+{ref}`setting-up-mlir`. It must be available to CMake before the next step.
+
+{%- endif %}
+
 4. Install the project and its development dependencies: <!-- rumdl-disable-line MD013 -->
 
    We highly recommend using modern, fast tooling for the development workflow.
@@ -405,9 +412,6 @@ guidelines and workflows, see {doc}`contributing`.
    ```
 
 {%- if project_type == "c++-mlir-python" %}
-
-6. Install LLVM/MLIR as described below. It is required to build MQT {{name}}
-   from source.
 
 (setting-up-mlir)=
 

--- a/templates/tooling.md
+++ b/templates/tooling.md
@@ -11,13 +11,13 @@ to understand the project's ecosystem.
 
 ## C++
 
-| Tool             | Description                          | Links / Notes                                                                                                 |
-| ---------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
-| **CMake**        | Build system.                        | [Documentation](https://cmake.org/).                                                                          |
-| **clang-format** | Code formatter (LLVM style).         | [Documentation](https://clang.llvm.org/docs/ClangFormat.html). Config: {code}`.clang-format` in project root. |
-| **clang-tidy**   | Static analysis and linting for C++. | [Documentation](https://clang.llvm.org/extra/clang-tidy/). Config: {code}`.clang-tidy` in project root.       |
-| **Doxygen**      | C++ API documentation (comments).    | [Documentation](https://www.doxygen.nl/). Rendered in Sphinx via [breathe](https://breathe.readthedocs.io/).  |
-| **GoogleTest**   | C++ unit testing.                    | [Primer](https://google.github.io/googletest/primer.html). Tests in {code}`test/`; run via CTest.             |
+| Tool             | Description                          | Links / Notes                                                                                                                                                                                 |
+| ---------------- | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **CMake**        | Build system.                        | [Documentation](https://cmake.org/).                                                                                                                                                          |
+| **clang-format** | Code formatter (LLVM style).         | [Documentation](https://clang.llvm.org/docs/ClangFormat.html). Config: {code}`.clang-format` in project root.                                                                                 |
+| **clang-tidy**   | Static analysis and linting for C++. | [Documentation](https://clang.llvm.org/extra/clang-tidy/). Config: {code}`.clang-tidy` in project root.                                                                                       |
+| **Doxygen**      | C++ API documentation (comments).    | [Documentation](https://www.doxygen.nl/). {% if repository == "core" %}Native HTML linked from Sphinx.{% else %}Rendered in Sphinx via [breathe](https://breathe.readthedocs.io/).{% endif %} |
+| **GoogleTest**   | C++ unit testing.                    | [Primer](https://google.github.io/googletest/primer.html). Tests in {code}`test/`; run via CTest.                                                                                             |
 
 ## C++/Python Bindings and Packaging
 

--- a/tests/test_render_templates.py
+++ b/tests/test_render_templates.py
@@ -50,14 +50,21 @@ def _check_files(files: list[Path]) -> None:
 
 @pytest.mark.parametrize("project_type", ["c++-python", "pure-python", "c++-mlir-python"])
 @pytest.mark.parametrize("has_changelog_and_upgrade_guide", [True, False])
-def test_non_other(temp_dir: Path, project_type: str, *, has_changelog_and_upgrade_guide: bool) -> None:
+@pytest.mark.parametrize("repository", ["test", "core"])
+def test_non_other(
+    temp_dir: Path,
+    project_type: str,
+    repository: str,
+    *,
+    has_changelog_and_upgrade_guide: bool,
+) -> None:
     """Test that templates for non-`other` projects are rendered correctly."""
     render_templates(
         target_dir=temp_dir,
         name="Test",
         organization="munich-quantum-toolkit",
         project_type=project_type,
-        repository="test",
+        repository=repository,
         has_changelog_and_upgrade_guide=has_changelog_and_upgrade_guide,
         synchronize_agents_md=True,
         synchronize_contribution_guide=True,


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

The development recipe builds the Python package before installing LLVM/MLIR,
and the documentation recipe bypasses the checked nox session. Move the native
prerequisite before the first package build and document the supported docs and
linkcheck commands. Describe Core's native Doxygen HTML while preserving Breathe
guidance for other projects.

Extend the existing render-and-format tests to cover Core as well as a generic
repository. [Core #2462](https://github.com/munich-quantum-toolkit/core/pull/2462) consumes the rendered installation,
contribution, and tooling pages.

Validation: all 13 rendering tests passed; `uv run prek run --all-files` passed.
No runtime API or dependency changes. Hosted CI and human review are pending.
Codex implemented and validated this change under explicit user authorization.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/templates/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
